### PR TITLE
Fix reassessment endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TRADE_FRONTEND
 Frontend for a forex and commodity trading information portal.
+All API requests target `http://localhost:3000`.
 
 When the backend API is unavailable, the signal form falls back to random test
 data so developers can continue working on the UI.

--- a/dashboard.html
+++ b/dashboard.html
@@ -379,7 +379,7 @@
       const handlePurchase = async () => {
         setLoading(true);
         try {
-          await fetch('/api/purchase', {
+          await fetch('http://localhost:3000/api/purchase', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ bundle: bundles[bundleIndex].credits, method, phone })


### PR DESCRIPTION
## Summary
- use explicit `http://localhost:3000` base for API requests so they hit the running backend
- mention API base in README

## Testing
- `grep -n "http://localhost:3000" -r`

------
https://chatgpt.com/codex/tasks/task_e_684edc24f81083208732dead6f348321